### PR TITLE
fix github PR from forked repo handling

### DIFF
--- a/src/main/java/com/checkmarx/flow/controller/GitHubController.java
+++ b/src/main/java/com/checkmarx/flow/controller/GitHubController.java
@@ -197,7 +197,7 @@ public class GitHubController {
                 excludeFolders = Arrays.asList(cxProperties.getExcludeFolders().split(","));
             }
             //build request object
-            String gitUrl = repository.getCloneUrl();
+            String gitUrl = pullRequest.getHead().getRepo().getCloneUrl();
             String token = properties.getToken();
             log.info("Using url: {}", gitUrl);
             String gitAuthUrl = gitUrl.replace(Constants.HTTPS, Constants.HTTPS.concat(token).concat("@"));


### PR DESCRIPTION
Previously, the GitHubController would set the clone URL to the repository's clone URL (equivalent to the PR base branch clone URL); this commit instead sets the clone URL to the clone URL of the pull request HEAD, so that scanned code changes are pulled from the correct repository, whether the PR was from a branch in the same repo or from a branch in a forked repository. Fixes #89